### PR TITLE
ZOT-202: Make the application start-up check configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@ Example `group_vars/dev`:
 ```
 ---
 ghe:
-#  upgrade_package_url: https://github-enterprise.s3.amazonaws.com/esx/updates/github-enterprise-esx-2.7.1.pkg
-  force_upgrade_to_latest: true
+  sign_in_check_string: Sign in to your account
+  #upgrade_package_url: https://github-enterprise.s3.amazonaws.com/esx/updates/github-enterprise-esx-2.7.1.pkg
+  #force_upgrade_to_latest: true
 zenoss_uid: /zport/dmd/Devices/Server/Linux/devices/github-dev.someplace.edu
 vm_name: changeme
 ```
 
-* The `ghe.force_upgrade_to_latest` variable forces `ghe-update-check` to ignore the current release series in favor of the latest version available.
-* The `ghe.upgrade_package_url` variable forces the playbook to download and run the specified upgrade package file. This option overrides `ghe.force_upgrade_to_latest` and should only be used to force the installation of a specific version.
+* `ghe.sign_in_check_string` - The string to search for when checking if the application has successfully come back up after an upgrade. For deployments using the default GitHub authentication, the value should be 'Sign in to your account' as shown in the example.
+* `ghe.force_upgrade_to_latest` - Force `ghe-update-check` to ignore the current release series in favor of the latest version available.
+* `ghe.upgrade_package_url` - Force the playbook to download and run the specified upgrade package file. This option overrides `ghe.force_upgrade_to_latest` and should only be used to install a specific version.
 
 ## Upgrading GitHub Enterprise
 

--- a/roles/upgrade-ghe/tasks/run_ghe_update_check.yml
+++ b/roles/upgrade-ghe/tasks/run_ghe_update_check.yml
@@ -2,7 +2,7 @@
 - name: set ghe_update_check_cmd with force_upgrade_to_latest
   set_fact:
     ghe_update_check_cmd: "ghe-update-check -i"
-  when: ghe is not undefined and ghe.force_upgrade_to_latest
+  when: ghe.force_upgrade_to_latest|default(false)|bool == true
 
 - name: set ghe_update_check_cmd to default
   set_fact:

--- a/roles/upgrade-ghe/tasks/run_upgrade.yml
+++ b/roles/upgrade-ghe/tasks/run_upgrade.yml
@@ -64,7 +64,6 @@
 - name: wait for sign-in page
   local_action: uri url=https://{{ inventory_hostname }} return_content=true status_code=200 validate_certs=true
   register: ghe_site
-  until: "'Enter your ONID username and password to login' in ghe_site.content"
+  until: "'{{ ghe.sign_in_check_string }}' in ghe_site.content"
   retries: 10
   delay: 60
-  when: "'dev' not in group_names"


### PR DESCRIPTION
Playbook now accepts a user-configurable string to look for when determining if the application has successfully restarted after an upgrade.

Also fixed a bug with the config logic when forcing upgrades to the latest version.

Fixes #4 