### PR TITLE
Fix #8: Warnings thrown when running playbook with ansible 2.3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Ansible playbook for GitHub Enterprise
 
+This playbook assumes you are running GitHub Enterprise under SSL.
+
 ## Roles
 
 * `upgrade_ghe` - upgrade GHE to latest version (as determined by `ghe-update-check`)
@@ -25,13 +27,15 @@ ghe:
   sign_in_check_string: Sign in to your account
   #upgrade_package_url: https://github-enterprise.s3.amazonaws.com/esx/updates/github-enterprise-esx-2.7.1.pkg
   #force_upgrade_to_latest: true
+  #validate_cert: true
 zenoss_uid: /zport/dmd/Devices/Server/Linux/devices/github-dev.someplace.edu
 vm_name: changeme
 ```
 
 * `ghe.sign_in_check_string` - The string to search for when checking if the application has successfully come back up after an upgrade. For deployments using the default GitHub authentication, the value should be 'Sign in to your account' as shown in the example.
-* `ghe.force_upgrade_to_latest` - Force `ghe-update-check` to ignore the current release series in favor of the latest version available.
-* `ghe.upgrade_package_url` - Force the playbook to download and run the specified upgrade package file. This option overrides `ghe.force_upgrade_to_latest` and should only be used to install a specific version.
+* `ghe.force_upgrade_to_latest` (optional) - Force `ghe-update-check` to ignore the current release series in favor of the latest version available.
+* `ghe.upgrade_package_url` (optional) - Force the playbook to download and run the specified upgrade package file. This option overrides `ghe.force_upgrade_to_latest` and should only be used to install a specific version.
+* `ghe.validate_cert` (optional) - Set to `false` to skip SSL certificate validation when checking if the application has successfully come back up after an upgrade. Not recommended unless you really need this!
 * `zenoss_uid` (optional) - Zenoss device uid for managing maintenance state
 * `vm_name` (optional) - VMware VM name that is running GitHub Enterprise
 

--- a/roles/upgrade-ghe/tasks/run_ghe_update_check.yml
+++ b/roles/upgrade-ghe/tasks/run_ghe_update_check.yml
@@ -17,7 +17,7 @@
 - name: verify ghe-update-check results
   fail:
     msg: "GitHub Enterprise is currently on the latest release"
-  when: "'Your GitHub Enterprise install is currently on the latest release' in '{{ gheupdatecheck.stdout_lines | last }}'"
+  when: "'Your GitHub Enterprise install is currently on the latest release' in gheupdatecheck.stdout_lines|last"
 
 - name: set ghe_package_filename
   set_fact:

--- a/roles/upgrade-ghe/tasks/run_upgrade.yml
+++ b/roles/upgrade-ghe/tasks/run_upgrade.yml
@@ -12,6 +12,7 @@
     uid: "{{ zenoss_uid }}"
     production_state: maintenance
   when: zenoss_uid is defined
+  no_log: true
 
 - name: snapshot VM
   local_action:
@@ -39,13 +40,13 @@
     - skip_ansible_lint
 
 - name: wait for server restart
-  local_action: wait_for host={{ inventory_hostname }} port=443 state=stopped delay=30 timeout=600
+  local_action: wait_for host={{ inventory_hostname }} port=443 state=stopped delay=30 timeout=900
 
 - name: wait for application to come back up
   local_action: command curl -s -k -o /dev/null -w "%{http_code}" https://{{ inventory_hostname }} warn=no
   register: ghe_site
   until: "ghe_site.stdout == '503'"
-  retries: 10
+  retries: 15
   delay: 60
   changed_when: False
 
@@ -66,8 +67,8 @@
   changed_when: False
 
 - name: wait for sign-in page
-  local_action: uri url=https://{{ inventory_hostname }} return_content=true status_code=200 validate_certs=true
+  local_action: uri url=https://{{ inventory_hostname }} return_content=true status_code=200 validate_certs={{ ghe.validate_cert|default(true)|bool }}
   register: ghe_site
-  until: "'{{ ghe.sign_in_check_string }}' in ghe_site.content"
+  until: "ghe.sign_in_check_string in ghe_site.content"
   retries: 10
   delay: 60


### PR DESCRIPTION
Also:
- Bumped up server restart timeout and app restart retry count,
  since upgrades are taking longer and longer.
- Added optional `ghe.validate_cert` flag to allow skipping SSL
  cert checks. This is useful when running a development (non-SSL)
  GHE instance but not recommended for production use.