### PR TITLE
Fix #16: "configuration run in progress" failure during upgrade

### DIFF
--- a/roles/upgrade-ghe/tasks/post_upgrade.yml
+++ b/roles/upgrade-ghe/tasks/post_upgrade.yml
@@ -10,9 +10,14 @@
   when:
     - zenoss_uid is defined
     - "'prod' in group_names"
+  no_log: true
 
 - name: disable maintenance mode in GHE
   command: ghe-maintenance -u
+  retries: 120
+  delay: 5
+  register: result
+  until: result.rc == 0
   changed_when: False
 
 - name: wait for sign-in page


### PR DESCRIPTION
In GHE 2.14, you can no longer disable maintenance mode while a
configuration run is in progress. Running the ghe-maintenance
command in this state results in a failed exit code, which fails
a playbook run.

This commit handles this case more gracefully by retrying the
command to disable maintenance mode until it completes with an exit
code of 0.